### PR TITLE
Add #inline method

### DIFF
--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -43,6 +43,18 @@ module Wisper
       is_enabled
       self
     end
+    
+    # Sets all broadcasters to InlineBroadcaster which broadcasts event
+    #  to the subscriber synchronously.
+    #
+    #  @return self
+    #
+    def self.inline
+      inline!
+      yield
+      restore!
+      self
+    end
 
     # Restores the original broadcasters configuration
     #


### PR DESCRIPTION
If there's `#fake`, there should be `#inline` that takes a block (especially if it's being mentioned in README 😉 )